### PR TITLE
Final bug sweep + rename ANALYSIS.md to WORKLOG.md

### DIFF
--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,10 +1,14 @@
-# Library Analysis & Work Log
+# Work Log — Improvements & Fixes
 
-Performance and correctness review of `@mikrostack/vir`, a React virtualized-list
-library, plus the work completed in response and the items still outstanding.
+A running log of the correctness fixes, performance work, and API changes made to
+`@mikrostack/vir`, a React virtualized-list library, plus the items still
+outstanding. Completed work is recorded in section 3; the live backlog is
+section 4. Newest work is appended.
 
-- **Reviewed:** June 2026, against `main` at `6a3f045`.
-- **Delivered:** PR #5 (fixes, performance, tests, CI) and PR #6 (docs), both merged.
+- **Origin:** a performance and correctness review in June 2026 against `main`
+  at `6a3f045` (sections 1–2 capture that initial pass).
+- **Merged so far:** PR #5 (fixes, performance, tests, CI), #6 (docs), and #8
+  (packaging, rendering, visibility API, playground, `scrollToItem`).
 
 ---
 
@@ -135,9 +139,9 @@ compare to one binary search plus a handful of reference checks.
 - Fixed a non-existent `content.position` field reference and the
   `VirtualizedItemProps` default type parameter.
 
-### Packaging & rendering — branch `outstanding-fixes`
+### Packaging, rendering, visibility & API — PR #8
 
-Picking up the lower-risk items from section 4 (on the branch, not yet merged):
+Picking up the lower-risk items from section 4, plus an API reshape:
 
 - **Packaging.** Added a conditional `exports` map (types-first per condition),
   `"sideEffects": false`, and `engines.node` `">=20"`; configured tsup to drop
@@ -181,6 +185,32 @@ winning over `contentRect`; `isVisible` viewport-vs-overscan; visibility
 enter/exit transitions and no-op-scroll silence; `scrollToItem` reveal and
 already-visible no-op), and the maximize tests were removed — 39 in total.
 
+### Bug sweep & this log's rename — branch `bug-sweep-and-doc`
+
+A final adversarial review (two independent passes over the core and the React
+layer). Most paths held up; the fixes:
+
+- **`getViewportInfo` dropped the gap term** before initialization, so the spacer
+  height jumped once the scroll container attached (only observable with
+  `gap > 0`). It now delegates to the gap-aware `getTotalHeight` in every state.
+- **Resize/scroll race on `scrollTopRatio`.** The proportional scroll-restore
+  after a container resize read `this.scrollTopRatio` in a deferred rAF, which a
+  concurrent scroll could clobber; the ratio is now captured in a local.
+- **Unbuilt-fallback scans** in `getVisibleItems` / `computeVisibleIds` kept the
+  monotonic early-`break`, and `scrollToItem`'s default-height estimate ignored
+  `gap`. Both are defensive paths *not* reachable under current invariants
+  (`buildMeasurements` always populates every id at the current version), but are
+  now correct should those invariants change.
+- **ResizeObserver hygiene.** The item observer is no longer nulled in its effect
+  cleanup, avoiding a transient second observer across a StrictMode remount.
+
+A regression test covers the gap-in-`totalHeight` fix — 40 in total. This file
+was also renamed from `ANALYSIS.md` to reflect its function as a running log.
+
+Separately, PR #9 lifted the playground video example's `playing` flag into its
+coordinator so it survives an item scrolling off-screen and back — modelling
+that per-item state belongs outside the (unmounted-while-off-screen) item.
+
 ---
 
 ## 4. Outstanding work
@@ -221,5 +251,9 @@ improvements, roughly in descending order of value.
 
 ## 5. Verification
 
-All work was verified locally (`tsc --noEmit`, `npm run build`, `npm test` — 39
-passing) and through CI on both PRs before merge.
+All work is verified locally (`tsc --noEmit`, `npm run build`, `npm test` — 40
+passing) and through CI before merge. Library changes are also smoke-tested in
+the playground (`npm run playground`). Note: the test runner currently requires
+Node 22+ locally (a transitive dep is ESM-only and the rolldown native binding
+hits the npm optional-deps bug on older Node); the build and the playground run
+on Node 20. CI runs Node 24.

--- a/src/components/VirtualizedList.tsx
+++ b/src/components/VirtualizedList.tsx
@@ -79,9 +79,12 @@ export const VirtualizedList = memo(
     }
 
     useEffect(() => {
+      // Disconnect on unmount but keep the instance: a disconnected
+      // ResizeObserver is reusable, and nulling it here would, under a
+      // StrictMode unmount/remount, leave a second observer created on the
+      // next render while mounted items still observe the first.
       return () => {
         itemObserverRef.current?.disconnect();
-        itemObserverRef.current = null;
       };
     }, []);
 

--- a/src/core/ScrollContainer.ts
+++ b/src/core/ScrollContainer.ts
@@ -16,7 +16,8 @@ export class ScrollContainer {
     private getOrderedIds: () => string[],
     private notify: () => void,
     private getTotalHeight: () => number,
-    private defaultItemHeight: number
+    private defaultItemHeight: number,
+    private gap: number
   ) {}
 
   init = (element: HTMLElement) => {
@@ -45,21 +46,24 @@ export class ScrollContainer {
           const newHeight = entry.contentRect.height;
           if (newHeight !== this.containerHeight && newHeight > 0) {
             const oldTotalHeight = this.getTotalHeight();
-            if (oldTotalHeight > 0) {
-              this.scrollTopRatio =
-                this.scrollTop /
-                Math.max(1, oldTotalHeight - this.containerHeight);
-            }
+            // Capture the pre-resize ratio in a local. A scroll event firing
+            // before the deferred rAF runs calls updateScrollTopRatio and would
+            // otherwise clobber this.scrollTopRatio, restoring the wrong offset.
+            const ratio =
+              oldTotalHeight > 0
+                ? this.scrollTop /
+                  Math.max(1, oldTotalHeight - this.containerHeight)
+                : this.scrollTopRatio;
+            this.scrollTopRatio = ratio;
 
             this.containerHeight = newHeight;
 
             requestAnimationFrame(() => {
               const targetElement = this.scrollContainerElement;
-              if (targetElement && this.scrollTopRatio > 0) {
+              if (targetElement && ratio > 0) {
                 const newTotalHeight = this.getTotalHeight();
                 const newScrollTop =
-                  this.scrollTopRatio *
-                  Math.max(0, newTotalHeight - this.containerHeight);
+                  ratio * Math.max(0, newTotalHeight - this.containerHeight);
                 targetElement.scrollTop = Math.max(0, newScrollTop);
               }
             });
@@ -115,7 +119,12 @@ export class ScrollContainer {
       const itemIndex = orderedIds.findIndex((id) => id === itemId);
 
       if (itemIndex !== -1) {
-        this.scrollToPosition(itemIndex * this.defaultItemHeight, false);
+        // Estimate the offset with the gap included, matching how
+        // buildMeasurements lays unmeasured items out.
+        this.scrollToPosition(
+          itemIndex * (this.defaultItemHeight + this.gap),
+          false
+        );
       }
       return;
     }

--- a/src/core/VirtualizedListManager.ts
+++ b/src/core/VirtualizedListManager.ts
@@ -74,7 +74,8 @@ export class VirtualizedListManager<TData = unknown, TTransformed = TData>
       this.getOrderedIds,
       this.notify,
       this.getTotalHeight,
-      this.defaultItemHeight
+      this.defaultItemHeight,
+      this.gap
     );
 
     this.uuid = Math.random().toString(36).substring(2, 10);
@@ -238,13 +239,11 @@ export class VirtualizedListManager<TData = unknown, TTransformed = TData>
     const totalCount = orderedIds.length;
     const totalHeight = this.getTotalHeight();
 
-    if (!this.isInitialized || totalCount === 0) {
-      return {
-        totalHeight: totalCount * this.defaultItemHeight,
-        totalCount,
-      };
-    }
-
+    // getTotalHeight is gap-aware and already falls back to a default-height
+    // estimate before the first build (and returns 0 when empty), so it is
+    // correct in every state — including not-yet-initialized. Using the raw
+    // `count * defaultItemHeight` here instead dropped the gap term and made
+    // the spacer height jump once initialized.
     return {
       totalHeight,
       totalCount,
@@ -280,11 +279,13 @@ export class VirtualizedListManager<TData = unknown, TTransformed = TData>
     // missing (nothing built yet), fall back to scanning from the start.
     let lo = 0;
     let hi = count;
+    let fellBack = false;
     while (lo < hi) {
       const mid = (lo + hi) >> 1;
       const m = this.measurements.getMeasurementById(orderedIds[mid]);
       if (!m) {
         lo = 0;
+        fellBack = true;
         break;
       }
       if (m.top + m.height < viewportTop) {
@@ -299,9 +300,10 @@ export class VirtualizedListManager<TData = unknown, TTransformed = TData>
       if (!measurement) continue;
 
       const itemTop = measurement.top;
-      // Tops are monotonic: everything after this is below the viewport
-      if (itemTop > viewportBottom) break;
-      // Only reachable on the unbuilt fallback path
+      // Tops are monotonic on the built path, so stop once past the viewport.
+      // On the fallback (unbuilt) path layout isn't coherent, so don't break
+      // early — scan the whole list.
+      if (!fellBack && itemTop > viewportBottom) break;
       if (itemTop + measurement.height < viewportTop) continue;
 
       const item = this.dataProvider.getItemById(orderedIds[i]);
@@ -356,11 +358,13 @@ export class VirtualizedListManager<TData = unknown, TTransformed = TData>
 
     let lo = 0;
     let hi = count;
+    let fellBack = false;
     while (lo < hi) {
       const mid = (lo + hi) >> 1;
       const m = this.measurements.getMeasurementById(orderedIds[mid]);
       if (!m) {
         lo = 0;
+        fellBack = true;
         break;
       }
       if (m.top + m.height < top) lo = mid + 1;
@@ -372,8 +376,9 @@ export class VirtualizedListManager<TData = unknown, TTransformed = TData>
       const m = this.measurements.getMeasurementById(orderedIds[i]);
       if (!m) continue;
       // Same strict intersection as `isVisible` in getVisibleItems: an item
-      // whose edge merely touches the window boundary does not count.
-      if (m.top >= bottom) break;
+      // whose edge merely touches the window boundary does not count. Don't
+      // break early on the unbuilt fallback path (layout isn't monotonic).
+      if (!fellBack && m.top >= bottom) break;
       if (m.top + m.height <= top) continue;
       ids.push(orderedIds[i]);
     }

--- a/test/VirtualizedListManager.test.ts
+++ b/test/VirtualizedListManager.test.ts
@@ -79,6 +79,18 @@ describe("VirtualizedListManager", () => {
     expect(visibleItems[3].measurement).toEqual({ top: 300, height: 100 });
   });
 
+  it("includes gap in totalHeight before the scroll container is attached", () => {
+    const { provider, notifyData } = createFakeProvider(10);
+    const manager = new VirtualizedListManager(provider, {
+      defaultItemHeight: 100,
+      gap: 10,
+    });
+    notifyData(); // builds measurements; not yet initialized (no scroll element)
+
+    // 10 * 100 + 9 gaps * 10 = 1090, not 1000 (gap must not be dropped)
+    expect(manager.getSnapshot().viewportInfo.totalHeight).toBe(1090);
+  });
+
   it("moves the window when scrolling", () => {
     const { manager } = createManager();
     manager.handleScroll(5000);


### PR DESCRIPTION
A final correctness sweep of the library plus a doc rename.

## Bug sweep

Two independent adversarial review passes (core layer + React layer). Most defensive paths held up under scrutiny; the fixes below are the real findings, split by reachability.

### Reachable today
- **`getViewportInfo` dropped the gap term before initialization** — the total/spacer height was computed as `count * defaultItemHeight` (no gaps) until the scroll container attached, then snapped to the gap-aware value, causing a scrollbar jump on mount whenever `gap > 0`. Now delegates to the gap-aware `getTotalHeight` in every state. (Regression test added.)
- **Resize/scroll race on `scrollTopRatio`** — the proportional scroll-restore after a container resize read `this.scrollTopRatio` inside a deferred `requestAnimationFrame`; a scroll firing in between calls `updateScrollTopRatio` and clobbers it, restoring the wrong offset. The ratio is now captured in a local for the rAF.

### Defensive correctness (not reachable under current invariants, fixed anyway)
- **Unbuilt-fallback scans** in `getVisibleItems` / `computeVisibleIds` retained the monotonic early-`break`, which would terminate the scan early on the (intentionally non-monotonic) fallback path. Guarded with a `fellBack` flag.
- **`scrollToItem` fallback estimate ignored `gap`** — `index * defaultItemHeight` instead of `index * (defaultItemHeight + gap)`. `gap` is now threaded into `ScrollContainer`.

  Both above are unreachable today because `buildMeasurements` always populates every ordered id at the current version atomically with `startNewVersion`, so `getMeasurementById` never returns `undefined` for a live id. Fixed so they're correct if that invariant ever changes.

### Hygiene
- The item `ResizeObserver` is no longer nulled in its effect cleanup (only disconnected), avoiding a transient second observer across a StrictMode unmount/remount. Not a crash — the render-body guard always recreates before use — just cleaner.

Two flagged items were deliberately **not** changed: `setOnVisibleChange` being called during render (it's the latest-callback ref pattern, no user-visible effect), and a "null observer crash" claim that doesn't actually occur (the render-body guard recreates the observer before any item reads it).

## Doc

Renamed `docs/ANALYSIS.md` → `docs/WORKLOG.md` — it's a running log of done + outstanding work, not a one-time analysis. Reframed the intro, marked the PR #8 work as merged, and recorded this sweep.

## Verification

`tsc --noEmit` clean, build clean, **40/40 tests pass** (Node 22 locally — see the note in WORKLOG.md §5), and the playground was smoke-tested in the browser (renders + windowed scroll intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)